### PR TITLE
Update  the statement `You can only reference a user by the ACCOUNT_ID in an owner file` in Doc of Pipelines as Code with Bitbucket Server

### DIFF
--- a/modules/op-using-pipelines-as-code-with-bitbucket-server.adoc
+++ b/modules/op-using-pipelines-as-code-with-bitbucket-server.adoc
@@ -88,7 +88,7 @@ spec:
       key: "webhook.secret" # Set this if you have a different key for your secret
 ----
 <1> Ensure that you have the right Bitbucket Server API URL without the `/api/v1.0` suffix. Usually, the default install has a `/rest` suffix.
-<2> You can only reference a user by the `ACCOUNT_ID` in an owner file.
+<2> Specify the BitBucket Server username.
 <3> {pac} assumes that the secret referred in the `git_provider.secret` spec and the `Repository` CR is in the same namespace.
 +
 [NOTE]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Need to Modify the statement `You can only reference a user by the ACCOUNT_ID in an owner file` as user is getting confused on how to get the ACCOUNT_ID.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-29885

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
	

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
