### PR TITLE
Update op-using-pipelines-as-code-with-bitbucket-cloud.adoc

### DIFF
--- a/modules/op-using-pipelines-as-code-with-bitbucket-cloud.adoc
+++ b/modules/op-using-pipelines-as-code-with-bitbucket-cloud.adoc
@@ -111,7 +111,7 @@ spec:
       name: "bitbucket-cloud-token" <2>
       key: "provider.token" # Set this if you have a different key in your secret
 ----
-<1> You can only reference a user by the `ACCOUNT_ID` in an owner file.
+<1> Specify the BitBucket Server username.
 <2> {pac} assumes that the secret referred in the `git_provider.secret` spec and the `Repository` CR is in the same namespace.
 
 +


### PR DESCRIPTION
Modifying `You can only reference a user by the ACCOUNT_ID in an owner file. ` statement in doc

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
